### PR TITLE
feat: Enhance category functionality and display

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "@testing-library/dom": "^10.4.0",
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^16.3.0",
+    "@testing-library/user-event": "^14.6.1",
     "@types/jest": "^29.5.14",
     "@types/node": "^20",
     "@types/react": "^19",

--- a/src/components/custom/PromptCard.tsx
+++ b/src/components/custom/PromptCard.tsx
@@ -31,8 +31,6 @@ export const PromptCard = ({ prompt, category, onCopy, onEdit, onDelete }: Promp
         <div className="flex justify-between items-start">
           <div>
             <CardTitle>{prompt.name}</CardTitle>
-            {category && <CardDescription>{category.name}</CardDescription>}
-            {!category && prompt.categoryId && <CardDescription>Category ID: {prompt.categoryId}</CardDescription>}
           </div>
           <div className="flex items-center">
             <Button variant="ghost" size="icon" onClick={(e) => { e.stopPropagation(); handleCopy(); }} aria-label="Copy prompt">

--- a/src/components/custom/PromptCard.tsx
+++ b/src/components/custom/PromptCard.tsx
@@ -1,18 +1,17 @@
-import { Prompt, Category } from '@/types';
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Prompt } from '@/types';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from '@/components/ui/dropdown-menu';
 import { Copy, Edit3, Trash2, MoreVertical } from 'lucide-react';
 
 interface PromptCardProps {
   prompt: Prompt;
-  category?: Category; // Optional: if category name needs to be displayed directly
   onCopy: (content: string) => void;
   onEdit: (prompt: Prompt) => void;
   onDelete: (promptId: string) => void;
 }
 
-export const PromptCard = ({ prompt, category, onCopy, onEdit, onDelete }: PromptCardProps) => {
+export const PromptCard = ({ prompt, onCopy, onEdit, onDelete }: PromptCardProps) => {
   const handleCopy = () => {
     onCopy(prompt.content);
   };

--- a/src/components/custom/PromptForm.test.tsx
+++ b/src/components/custom/PromptForm.test.tsx
@@ -3,65 +3,103 @@ import userEvent from '@testing-library/user-event';
 import '@testing-library/jest-dom';
 import { PromptForm } from './PromptForm'; // Adjust path
 import { Category, Prompt } from '../../types'; // Adjust path
-// import * as localStorageUtils from '../../lib/localStorage'; // To mock localStorage functions - No longer needed
 
 // Mock lucide-react icons
 jest.mock('lucide-react', () => ({
-  ...jest.requireActual('lucide-react'), // Import and retain default behavior for other icons
+  ...jest.requireActual('lucide-react'),
   PlusCircle: () => <svg data-testid="plus-circle-icon" />,
   ChevronsUpDown: () => <svg data-testid="chevrons-up-down-icon" />,
   Check: () => <svg data-testid="check-icon" />,
-  Search: () => <svg data-testid="search-icon" />, // Added Search icon
+  Search: () => <svg data-testid="search-icon" />,
 }));
 
 // Mock DialogClose to prevent asChild issues in JSDOM
 jest.mock('@/components/ui/dialog', () => {
   const React = jest.requireActual('react');
   const originalModule = jest.requireActual('@/components/ui/dialog');
-  return {
-    ...originalModule,
-    DialogClose: React.forwardRef(({ children, asChild, ...props }: any, ref: any) => {
+
+  interface MockDialogCloseProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+    children?: React.ReactNode;
+    asChild?: boolean;
+  }
+
+  const DialogCloseComponent = React.forwardRef<HTMLButtonElement, MockDialogCloseProps>(
+    ({ children, asChild, ...props }, ref) => {
       if (asChild && React.isValidElement(children)) {
-        // Apply props to the child, similar to what Slot would do.
-        // This helps if the child is our UI Button that can handle these props.
-        return React.cloneElement(children, { ...props, ...children.props, ref });
+        const childProps = children.props as Record<string, unknown>;
+        return React.cloneElement(children as React.ReactElement, { ...props, ...childProps, ref });
       }
       return (
         <button {...props} ref={ref} data-testid="mocked-dialog-close">
           {children}
         </button>
       );
-    }),
+    }
+  );
+  DialogCloseComponent.displayName = 'DialogClose';
+
+  return {
+    ...originalModule,
+    DialogClose: DialogCloseComponent,
   };
 });
 
-// Minimal Popover mock - primarily to ensure content is available.
+// Minimal Popover mock
 jest.mock('@radix-ui/react-popover', () => {
   const React = jest.requireActual('react');
   const originalModule = jest.requireActual('@radix-ui/react-popover');
-  return {
-    ...originalModule,
-    Root: ({ children }) => <>{children}</>,
-    Trigger: React.forwardRef(({ children, asChild, ...props }, ref) => {
+
+  interface MockPopoverRootProps { children?: React.ReactNode; open?: boolean; onOpenChange?: (open: boolean) => void; }
+  const PopoverRoot = ({ children }: MockPopoverRootProps) => <>{children}</>;
+  PopoverRoot.displayName = 'PopoverRoot';
+
+  interface MockPopoverTriggerProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+    children?: React.ReactNode;
+    asChild?: boolean;
+  }
+  const PopoverTrigger = React.forwardRef<HTMLButtonElement, MockPopoverTriggerProps>(
+    ({ children, asChild, ...props }, ref) => {
       if (asChild && React.isValidElement(children)) {
-        const childProps = children.props as any;
-        return React.cloneElement(children, {
+        const childProps = children.props as Record<string, unknown>;
+        return React.cloneElement(children as React.ReactElement, {
           ...props,
           ...childProps,
           ref,
-          onClick: (e) => {
+          onClick: (e: React.MouseEvent<HTMLButtonElement>) => {
             if (props.onClick) props.onClick(e);
-            if (childProps.onClick) childProps.onClick(e);
+            if (typeof childProps.onClick === 'function') childProps.onClick(e);
           },
           "data-testid": props['data-testid'] || childProps['data-testid'] || "mock-popover-trigger-child"
         });
       }
       return <button {...props} ref={ref} data-testid="mock-popover-trigger">{children}</button>;
-    }),
-    Content: React.forwardRef(({ children, sideOffset, align, ...props }, ref) => ( // Destructure and omit sideOffset, align
-      <div {...props} ref={ref} data-testid="mock-popover-content">{children}</div>
-    )),
-    Portal: ({ children }) => <>{children}</>,
+    }
+  );
+  PopoverTrigger.displayName = 'PopoverTrigger';
+
+  interface MockPopoverContentProps extends React.HTMLAttributes<HTMLDivElement> {
+    children?: React.ReactNode;
+    sideOffset?: number;
+    align?: string;
+  }
+  const PopoverContent = React.forwardRef<HTMLDivElement, MockPopoverContentProps>(
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    ({ children, sideOffset, align, ...otherProps }, ref) => (
+      <div {...otherProps} ref={ref} data-testid="mock-popover-content">{children}</div>
+    )
+  );
+  PopoverContent.displayName = 'PopoverContent';
+
+  interface MockPopoverPortalProps { children?: React.ReactNode; }
+  const PopoverPortal = ({ children }: MockPopoverPortalProps) => <>{children}</>;
+  PopoverPortal.displayName = 'PopoverPortal';
+
+  return {
+    ...originalModule,
+    Root: PopoverRoot,
+    Trigger: PopoverTrigger,
+    Content: PopoverContent,
+    Portal: PopoverPortal,
   };
 });
 
@@ -69,66 +107,82 @@ jest.mock('@radix-ui/react-popover', () => {
 jest.mock('@/components/ui/command', () => {
   const React = jest.requireActual('react');
 
-  const Command = React.forwardRef(({ children, ...props }: any, ref: any) => <div ref={ref} {...props} data-testid="mock-command-root">{children}</div>);
-  Command.displayName = 'Command';
+  interface MockCommandProps extends React.HTMLAttributes<HTMLDivElement> { children?: React.ReactNode; }
+  const CommandComponent = React.forwardRef<HTMLDivElement, MockCommandProps>(
+    ({ children, ...props }, ref) => <div ref={ref} {...props} data-testid="mock-command-root">{children}</div>
+  );
+  CommandComponent.displayName = 'Command';
 
-  const CommandInput = React.forwardRef(({ value, onValueChange, ...props }: any, ref: any) => (
-    <input
-      ref={ref}
-      {...props}
-      value={value || ''} // Ensure value is controlled
-      onChange={(e) => onValueChange && onValueChange(e.target.value)}
-      data-testid="mock-command-input"
-      placeholder={props.placeholder || "Search..."} // Carry over placeholder
-    />
-  ));
-  CommandInput.displayName = 'CommandInput';
+  interface MockCommandInputProps extends React.InputHTMLAttributes<HTMLInputElement> {
+    value?: string;
+    onValueChange?: (value: string) => void;
+  }
+  const CommandInputComponent = React.forwardRef<HTMLInputElement, MockCommandInputProps>(
+    ({ value, onValueChange, ...props }, ref) => (
+      <input
+        ref={ref}
+        {...props}
+        value={value || ''}
+        onChange={(e) => onValueChange && onValueChange(e.target.value)}
+        data-testid="mock-command-input"
+        placeholder={props.placeholder || "Search..."}
+      />
+    )
+  );
+  CommandInputComponent.displayName = 'CommandInput';
 
-  const CommandList = React.forwardRef(({ children, ...props }: any, ref: any) => <div ref={ref} {...props} data-testid="mock-command-list">{children}</div>);
-  CommandList.displayName = 'CommandList';
+  interface MockCommandListProps extends React.HTMLAttributes<HTMLDivElement> { children?: React.ReactNode; }
+  const CommandListComponent = React.forwardRef<HTMLDivElement, MockCommandListProps>(
+    ({ children, ...props }, ref) => <div ref={ref} {...props} data-testid="mock-command-list">{children}</div>
+  );
+  CommandListComponent.displayName = 'CommandList';
 
-  const CommandEmpty = React.forwardRef(({ children, ...props }: any, ref: any) => <div ref={ref} {...props} data-testid="mock-command-empty">{children || 'No results'}</div>);
-  CommandEmpty.displayName = 'CommandEmpty';
+  interface MockCommandEmptyProps extends React.HTMLAttributes<HTMLDivElement> { children?: React.ReactNode; }
+  const CommandEmptyComponent = React.forwardRef<HTMLDivElement, MockCommandEmptyProps>(
+    ({ children, ...props }, ref) => <div ref={ref} {...props} data-testid="mock-command-empty">{children || 'No results'}</div>
+  );
+  CommandEmptyComponent.displayName = 'CommandEmpty';
 
-  const CommandGroup = React.forwardRef(({ children, ...props }: any, ref: any) => <div ref={ref} {...props} data-testid="mock-command-group">{children}</div>);
-  CommandGroup.displayName = 'CommandGroup';
+  interface MockCommandGroupProps extends React.HTMLAttributes<HTMLDivElement> { children?: React.ReactNode; }
+  const CommandGroupComponent = React.forwardRef<HTMLDivElement, MockCommandGroupProps>(
+    ({ children, ...props }, ref) => <div ref={ref} {...props} data-testid="mock-command-group">{children}</div>
+  );
+  CommandGroupComponent.displayName = 'CommandGroup';
 
-  const CommandItem = React.forwardRef(({ children, onSelect, value, ...props }: any, ref: any) => (
-    <div
-      ref={ref}
-      {...props}
-      onClick={() => onSelect && onSelect(value)} // Simulate selection by calling onSelect with value
-      role="option"
-      data-value={value}
-      data-testid="mock-command-item"
-      tabIndex={0} // Make it focusable for userEvent
-    >
-      {children}
-    </div>
-  ));
-  CommandItem.displayName = 'CommandItem';
+  interface MockCommandItemProps extends React.HTMLAttributes<HTMLDivElement> {
+    children?: React.ReactNode;
+    onSelect?: (value: string) => void;
+    value?: string;
+    'aria-selected'?: boolean;
+  }
+  const CommandItemComponent = React.forwardRef<HTMLDivElement, MockCommandItemProps>(
+    ({ children, onSelect, value, ...props }, ref) => (
+      <div
+        ref={ref}
+        {...props}
+        onClick={() => onSelect && onSelect(value || '')}
+        role="option"
+        aria-selected={props['aria-selected'] || false}
+        data-value={value}
+        data-testid="mock-command-item"
+        tabIndex={0}
+      >
+        {children}
+      </div>
+    )
+  );
+  CommandItemComponent.displayName = 'CommandItem';
 
   return {
     __esModule: true,
-    Command,
-    CommandInput,
-    CommandList,
-    CommandEmpty,
-    CommandGroup,
-    CommandItem,
+    Command: CommandComponent,
+    CommandInput: CommandInputComponent,
+    CommandList: CommandListComponent,
+    CommandEmpty: CommandEmptyComponent,
+    CommandGroup: CommandGroupComponent,
+    CommandItem: CommandItemComponent,
   };
 });
-
-
-// Mock the localStorage utility functions if needed for specific tests,
-// but PromptForm itself doesn't directly call ls.addCategory for example.
-// It calls onSubmit which then handles category creation logic in the parent (page.tsx).
-// So, direct mocks of ls.addCategory might not be necessary here.
-// jest.mock('../../lib/localStorage', () => ({
-//   ...jest.requireActual('../../lib/localStorage'),
-//   getCategories: jest.fn(),
-//   addCategory: jest.fn(),
-// }));
 
 const mockCategories: Category[] = [
   { id: 'cat1', name: 'Category 1' },
@@ -136,12 +190,10 @@ const mockCategories: Category[] = [
   { id: 'cat3', name: 'Another Category' },
 ];
 
-// New test suite for PromptForm with Combobox
 describe('PromptForm Component with Combobox', () => {
   const onSubmitMock = jest.fn();
   const onCloseMock = jest.fn();
-
-  let alertSpy;
+  let alertSpy: jest.SpyInstance;
 
   beforeEach(() => {
     jest.clearAllMocks();
@@ -149,7 +201,7 @@ describe('PromptForm Component with Combobox', () => {
   });
 
   afterEach(() => {
-    alertSpy.mockRestore(); // Restore original window.alert
+    alertSpy.mockRestore();
   });
 
   const defaultProps = {
@@ -160,24 +212,20 @@ describe('PromptForm Component with Combobox', () => {
     categories: mockCategories,
   };
 
-  // Helper to render with specific props
   const renderPromptForm = (props?: Partial<typeof defaultProps>) => {
     return render(<PromptForm {...defaultProps} {...props} />);
   };
 
-  // Basic render test (optional, but good to have)
   it('renders the form with all fields', () => {
     renderPromptForm();
     expect(screen.getByLabelText(/name/i)).toBeInTheDocument();
     expect(screen.getByLabelText(/content/i)).toBeInTheDocument();
     expect(screen.getByLabelText(/category/i)).toBeInTheDocument();
     expect(screen.getByRole('button', { name: /create prompt/i })).toBeInTheDocument();
-    // With DialogClose mocked to handle asChild, this should now find only one.
     expect(screen.getByRole('button', { name: /cancel/i })).toBeInTheDocument();
   });
 
-  // Helper to fill common form fields
-  const fillFormFields = async (user, name, content) => {
+  const fillFormFields = async (user: ReturnType<typeof userEvent.setup>, name: string, content: string) => {
     await user.type(screen.getByLabelText(/name/i), name);
     await user.type(screen.getByLabelText(/content/i), content);
   };
@@ -185,94 +233,49 @@ describe('PromptForm Component with Combobox', () => {
   describe('Category Combobox: Display and Initial Value', () => {
     it('shows placeholder when no initialData is provided', () => {
       renderPromptForm();
-      // The trigger button for the combobox
       const categoryComboboxTrigger = screen.getByRole('combobox', { name: /category/i });
       expect(categoryComboboxTrigger).toHaveTextContent(/select or create category.../i);
     });
 
     it('shows category name when initialData has a valid categoryId', () => {
       const initialPrompt: Prompt = {
-        id: 'p1',
-        name: 'Test Prompt',
-        content: 'Test Content',
-        categoryId: 'cat1', // Exists in mockCategories
-        createdAt: new Date().toISOString(),
-        updatedAt: new Date().toISOString(),
+        id: 'p1', name: 'Test Prompt', content: 'Test Content', categoryId: 'cat1',
+        createdAt: new Date().toISOString(), updatedAt: new Date().toISOString(),
       };
       renderPromptForm({ initialData: initialPrompt });
       const categoryComboboxTrigger = screen.getByRole('combobox', { name: /category/i });
-      expect(categoryComboboxTrigger).toHaveTextContent(mockCategories[0].name); // "Category 1"
+      expect(categoryComboboxTrigger).toHaveTextContent(mockCategories[0].name);
     });
 
-    it('shows "Create <categoryName>" in trigger if initialData.categoryName is set but not in categories list', () => {
-      // This scenario assumes that if initialData has a categoryId not in the list,
-      // but somehow a category name was derived (e.g. if PromptForm's useEffect sets categoryName directly
-      // from a non-existent category, or if categoryId was actually a name string).
-      // Based on current PromptForm, if categoryId doesn't match, categoryName remains empty from initialData.
-      // Let's refine this: if initialData.categoryId is not found, categoryName in PromptForm becomes '',
-      // so it should show the placeholder.
+    it('shows placeholder if initialData categoryId is not found', () => {
       const initialPrompt: Prompt = {
-        id: 'p2',
-        name: 'Test Prompt 2',
-        content: 'Test Content 2',
-        categoryId: 'cat-unknown', // Does NOT exist in mockCategories
-        createdAt: new Date().toISOString(),
-        updatedAt: new Date().toISOString(),
+        id: 'p2', name: 'Test Prompt 2', content: 'Test Content 2', categoryId: 'cat-unknown',
+        createdAt: new Date().toISOString(), updatedAt: new Date().toISOString(),
       };
       renderPromptForm({ initialData: initialPrompt });
       const categoryComboboxTrigger = screen.getByRole('combobox', { name: /category/i });
-      // In PromptForm: `const currentCategory = categories.find(cat => cat.id === initialData.categoryId);`
-      // `setCategoryName(currentCategory ? currentCategory.name : '');`
-      // So, if not found, categoryName is '', leading to placeholder.
       expect(categoryComboboxTrigger).toHaveTextContent(/select or create category.../i);
     });
-
-    it('shows initial categoryName in trigger if initialData has categoryId and name, even if ID is weird but name is found', () => {
-        // Test case: initialData.categoryId is 'cat1', useEffect will find 'Category 1' and set it.
-        const initialPrompt: Prompt = {
-            id: 'p1',
-            name: 'Test Prompt',
-            content: 'Test Content',
-            categoryId: 'cat1',
-            createdAt: new Date().toISOString(),
-            updatedAt: new Date().toISOString(),
-          };
-        renderPromptForm({ initialData: initialPrompt });
-        const categoryComboboxTrigger = screen.getByRole('combobox', { name: /category/i });
-        expect(categoryComboboxTrigger).toHaveTextContent('Category 1');
-      });
   });
 
   describe('Category Combobox: Selecting an Existing Category', () => {
     it('allows selecting an existing category and submits with it', async () => {
-      renderPromptForm();
       const user = userEvent.setup();
-
+      renderPromptForm();
       await fillFormFields(user, 'Test Prompt Name', 'Test Prompt Content');
 
-      // Click the mock popover trigger (which is now the actual Button from PromptForm due to asChild)
       const categoryComboboxTrigger = screen.getByRole('combobox', { name: /category/i });
       await user.click(categoryComboboxTrigger);
 
-      // Select "Category 2" from the list
-      // CommandItems have role 'option' in Radix Command
-      const categoryOption = await screen.findByRole('option', { name: mockCategories[1].name }); // "Category 2"
+      const categoryOption = await screen.findByRole('option', { name: mockCategories[1].name });
       await user.click(categoryOption);
-
-      // Verify the trigger now shows "Category 2"
       expect(categoryComboboxTrigger).toHaveTextContent(mockCategories[1].name);
 
-      // Submit the form
       await user.click(screen.getByRole('button', { name: /create prompt/i }));
-
       await waitFor(() => {
         expect(onSubmitMock).toHaveBeenCalledWith(
-          {
-            name: 'Test Prompt Name',
-            content: 'Test Prompt Content',
-            categoryId: '', // categoryId is set by the parent component based on categoryName
-          },
-          mockCategories[1].name // Submitted category name should be "Category 2"
+          { name: 'Test Prompt Name', content: 'Test Prompt Content', categoryId: '' },
+          mockCategories[1].name
         );
       });
     });
@@ -280,67 +283,43 @@ describe('PromptForm Component with Combobox', () => {
 
   describe('Category Combobox: Creating a New Category', () => {
     it('allows creating a new category and submits with it', async () => {
-      renderPromptForm();
       const user = userEvent.setup();
+      renderPromptForm();
       const newCategoryName = 'My New Custom Category';
-
       await fillFormFields(user, 'Another Test Prompt', 'Some interesting content');
 
-      // Click the mock popover trigger
       const categoryComboboxTrigger = screen.getByRole('combobox', { name: /category/i });
       await user.click(categoryComboboxTrigger);
 
       const searchInput = screen.getByPlaceholderText(/search or create category.../i);
       await user.type(searchInput, newCategoryName);
 
-      // Click the "Create new category" button that appears in CommandEmpty
-      // This button appears in CommandEmpty, its text is "Create "{newCategoryName}""
       const createButton = await screen.findByRole('button', { name: `Create "${newCategoryName}"` });
       await user.click(createButton);
-
-      // Verify the trigger now shows the new category name (or part of it, like "Create ...")
-      // The current implementation of PromptForm shows `Create "Category Name"` if not found in `categories` prop,
-      // OR the actual name if it matches what's typed. After creation click, it sets `categoryName` directly.
-      // So the trigger should reflect the new name.
-      // The Popover mock makes the trigger a simple button. We check its text if applicable,
-      // but the main verification is that categoryName state is set correctly.
-      // The actual trigger text from PromptForm might be complex to assert with this mock.
-      // Let's focus on the onSubmit call.
-      // The text content of the actual combobox trigger (which is also the mocked PopoverTrigger)
-      // should update based on the categoryName state.
       expect(screen.getByRole('combobox', { name: /category/i })).toHaveTextContent(newCategoryName);
 
-      // Submit the form
       await user.click(screen.getByRole('button', { name: /create prompt/i }));
-
       await waitFor(() => {
         expect(onSubmitMock).toHaveBeenCalledWith(
-          {
-            name: 'Another Test Prompt',
-            content: 'Some interesting content',
-            categoryId: '', // categoryId is set by the parent
-          },
-          newCategoryName // Submitted category name should be the new one
+          { name: 'Another Test Prompt', content: 'Some interesting content', categoryId: '' },
+          newCategoryName
         );
       });
     });
 
     it('filters suggestions when typing into search input', async () => {
-      renderPromptForm();
       const user = userEvent.setup();
-
-      // Click the mock popover trigger
+      renderPromptForm();
       const categoryComboboxTrigger = screen.getByRole('combobox', { name: /category/i });
       await user.click(categoryComboboxTrigger);
 
       const searchInput = screen.getByPlaceholderText(/search or create category.../i);
-      await user.type(searchInput, 'Another'); // Should match "Another Category"
+      await user.type(searchInput, 'Another');
 
       expect(screen.getByRole('option', { name: 'Another Category' })).toBeVisible();
-      expect(screen.queryByRole('option', { name: 'Category 1' })).not.toBeInTheDocument(); // Or .not.toBeVisible() if it's just hidden
+      expect(screen.queryByRole('option', { name: 'Category 1' })).not.toBeInTheDocument();
       expect(screen.queryByRole('option', { name: 'Category 2' })).not.toBeInTheDocument();
 
-      // Clear search and check again
       await user.clear(searchInput);
       expect(screen.getByRole('option', { name: 'Category 1' })).toBeVisible();
       expect(screen.getByRole('option', { name: 'Category 2' })).toBeVisible();
@@ -350,22 +329,16 @@ describe('PromptForm Component with Combobox', () => {
 
   describe('Category Combobox: Interaction with initialData', () => {
     const promptWithCategory1: Prompt = {
-      id: 'prompt-initial-123',
-      name: 'Initial Prompt Name',
-      content: 'Initial prompt content here.',
-      categoryId: 'cat1', // "Category 1"
-      createdAt: new Date().toISOString(),
-      updatedAt: new Date().toISOString(),
+      id: 'prompt-initial-123', name: 'Initial Prompt Name', content: 'Initial prompt content here.',
+      categoryId: 'cat1', createdAt: new Date().toISOString(), updatedAt: new Date().toISOString(),
     };
 
     it('allows changing an existing category when editing a prompt', async () => {
-      renderPromptForm({ initialData: promptWithCategory1 });
       const user = userEvent.setup();
-
+      renderPromptForm({ initialData: promptWithCategory1 });
       const categoryComboboxTrigger = screen.getByRole('combobox', { name: /category/i });
-      expect(categoryComboboxTrigger).toHaveTextContent(mockCategories[0].name); // "Category 1"
+      expect(categoryComboboxTrigger).toHaveTextContent(mockCategories[0].name);
 
-      // Fill out other form fields
       const nameInput = screen.getByLabelText(/name/i);
       await user.clear(nameInput);
       await user.type(nameInput, 'Updated Prompt Name');
@@ -373,58 +346,42 @@ describe('PromptForm Component with Combobox', () => {
       await user.clear(contentInput);
       await user.type(contentInput, 'Updated Prompt Content');
 
-      // Open and change the category - categoryComboboxTrigger is already defined
       await user.click(categoryComboboxTrigger);
-      const categoryOption2 = await screen.findByRole('option', { name: mockCategories[1].name }); // "Category 2"
+      const categoryOption2 = await screen.findByRole('option', { name: mockCategories[1].name });
       await user.click(categoryOption2);
-      expect(categoryComboboxTrigger).toHaveTextContent(mockCategories[1].name); // Check the actual trigger
+      expect(categoryComboboxTrigger).toHaveTextContent(mockCategories[1].name);
 
-      // Submit the form (button should say "Save Changes")
       await user.click(screen.getByRole('button', { name: /save changes/i }));
-
       await waitFor(() => {
         expect(onSubmitMock).toHaveBeenCalledWith(
-          {
-            name: 'Updated Prompt Name',
-            content: 'Updated Prompt Content',
-            categoryId: '', // Parent handles ID resolution
-          },
-          mockCategories[1].name // New category name "Category 2"
+          { name: 'Updated Prompt Name', content: 'Updated Prompt Content', categoryId: '' },
+          mockCategories[1].name
         );
       });
     });
 
     it('allows creating a new category when editing a prompt', async () => {
-      renderPromptForm({ initialData: promptWithCategory1 });
       const user = userEvent.setup();
+      renderPromptForm({ initialData: promptWithCategory1 });
       const brandNewCategoryName = 'Super New Editing Category';
-
       const categoryComboboxTrigger = screen.getByRole('combobox', { name: /category/i });
-      expect(categoryComboboxTrigger).toHaveTextContent(mockCategories[0].name); // "Category 1"
+      expect(categoryComboboxTrigger).toHaveTextContent(mockCategories[0].name);
 
-      // Update other fields
       const nameInput = screen.getByLabelText(/name/i);
       await user.clear(nameInput);
       await user.type(nameInput, 'Name For New Cat Edit');
 
-      // Open, type, and create new category - categoryComboboxTrigger is already defined
       await user.click(categoryComboboxTrigger);
       const searchInput = screen.getByPlaceholderText(/search or create category.../i);
       await user.type(searchInput, brandNewCategoryName);
       const createButton = await screen.findByRole('button', { name: `Create "${brandNewCategoryName}"` });
       await user.click(createButton);
-      expect(categoryComboboxTrigger).toHaveTextContent(brandNewCategoryName); // Check the actual trigger
+      expect(categoryComboboxTrigger).toHaveTextContent(brandNewCategoryName);
 
-      // Submit
       await user.click(screen.getByRole('button', { name: /save changes/i }));
-
       await waitFor(() => {
         expect(onSubmitMock).toHaveBeenCalledWith(
-          {
-            name: 'Name For New Cat Edit',
-            content: promptWithCategory1.content, // Content was not changed in this test
-            categoryId: '',
-          },
+          { name: 'Name For New Cat Edit', content: promptWithCategory1.content, categoryId: '' },
           brandNewCategoryName
         );
       });

--- a/src/components/custom/PromptForm.test.tsx
+++ b/src/components/custom/PromptForm.test.tsx
@@ -1,9 +1,9 @@
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import '@testing-library/jest-dom';
 import { PromptForm } from './PromptForm'; // Adjust path
 import { Category, Prompt } from '../../types'; // Adjust path
-import * as localStorageUtils from '../../lib/localStorage'; // To mock localStorage functions
+// import * as localStorageUtils from '../../lib/localStorage'; // To mock localStorage functions - No longer needed
 
 // Mock lucide-react icons
 jest.mock('lucide-react', () => ({

--- a/src/components/custom/PromptForm.test.tsx
+++ b/src/components/custom/PromptForm.test.tsx
@@ -1,4 +1,5 @@
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import '@testing-library/jest-dom';
 import { PromptForm } from './PromptForm'; // Adjust path
 import { Category, Prompt } from '../../types'; // Adjust path
@@ -6,197 +7,303 @@ import * as localStorageUtils from '../../lib/localStorage'; // To mock localSto
 
 // Mock lucide-react icons
 jest.mock('lucide-react', () => ({
+  ...jest.requireActual('lucide-react'), // Import and retain default behavior for other icons
   PlusCircle: () => <svg data-testid="plus-circle-icon" />,
+  ChevronsUpDown: () => <svg data-testid="chevrons-up-down-icon" />,
+  Check: () => <svg data-testid="check-icon" />,
 }));
 
-// Mock the localStorage utility functions
-jest.mock('../../lib/localStorage', () => ({
-  ...jest.requireActual('../../lib/localStorage'),
-  getCategories: jest.fn(),
-  addCategory: jest.fn(),
-}));
+// Mock the localStorage utility functions if needed for specific tests,
+// but PromptForm itself doesn't directly call ls.addCategory for example.
+// It calls onSubmit which then handles category creation logic in the parent (page.tsx).
+// So, direct mocks of ls.addCategory might not be necessary here.
+// jest.mock('../../lib/localStorage', () => ({
+//   ...jest.requireActual('../../lib/localStorage'),
+//   getCategories: jest.fn(),
+//   addCategory: jest.fn(),
+// }));
 
 const mockCategories: Category[] = [
   { id: 'cat1', name: 'Category 1' },
   { id: 'cat2', name: 'Category 2' },
+  { id: 'cat3', name: 'Another Category' },
 ];
 
-// Skipping these tests due to difficulties testing complex Radix UI components in JSDOM.
-// These components are recommended for integration or E2E testing.
-describe.skip('PromptForm Component', () => {
+// New test suite for PromptForm with Combobox
+describe('PromptForm Component with Combobox', () => {
   const onSubmitMock = jest.fn();
-  const onCancelMock = jest.fn();
+  const onCloseMock = jest.fn(); // Renamed from onCancelMock for clarity with PromptForm props
 
   beforeEach(() => {
     jest.clearAllMocks();
-    (localStorageUtils.getCategories as jest.Mock).mockReturnValue(mockCategories);
-    (localStorageUtils.addCategory as jest.Mock).mockImplementation((name) => ({ id: `new-${name}`, name }));
+    // Example if you still need to mock ls.getCategories for some reason, though PromptForm receives categories as prop
+    // (localStorageUtils.getCategories as jest.Mock).mockReturnValue(mockCategories);
   });
 
-  const renderForm = (initialData?: Partial<Prompt>) => {
-    return render(
-      <PromptForm
-        onSubmit={onSubmitMock}
-        onCancel={onCancelMock}
-        initialData={initialData}
-        categories={mockCategories} // Pass categories directly if PromptForm expects it
-      />
-    );
+  const defaultProps = {
+    isOpen: true,
+    onClose: onCloseMock,
+    onSubmit: onSubmitMock,
+    initialData: null,
+    categories: mockCategories,
   };
 
-  it('renders correctly with initial empty state', () => {
-    renderForm();
-    expect(screen.getByLabelText(/title/i)).toBeInTheDocument();
+  // Helper to render with specific props
+  const renderPromptForm = (props?: Partial<typeof defaultProps>) => {
+    return render(<PromptForm {...defaultProps} {...props} />);
+  };
+
+  // Basic render test (optional, but good to have)
+  it('renders the form with all fields', () => {
+    renderPromptForm();
+    expect(screen.getByLabelText(/name/i)).toBeInTheDocument(); // Name field from PromptForm
     expect(screen.getByLabelText(/content/i)).toBeInTheDocument();
-    expect(screen.getByLabelText(/category/i)).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: /save/i })).toBeInTheDocument();
+    expect(screen.getByLabelText(/category/i)).toBeInTheDocument(); // This is the Label for the Combobox
+    expect(screen.getByRole('button', { name: /create prompt/i })).toBeInTheDocument(); // Or "Save Changes"
     expect(screen.getByRole('button', { name: /cancel/i })).toBeInTheDocument();
   });
 
-  it('renders with initialData if provided', () => {
-    const initialPrompt: Partial<Prompt> = {
-      title: 'Initial Title',
-      content: 'Initial Content',
-      categoryId: 'cat1',
-    };
-    renderForm(initialPrompt);
-    expect(screen.getByLabelText(/title/i)).toHaveValue(initialPrompt.title);
-    expect(screen.getByLabelText(/content/i)).toHaveValue(initialPrompt.content);
-    // For category, it's a select. Need to check the selected option.
-    // The value of the select element itself will be the categoryId.
-    expect(screen.getByLabelText(/category/i)).toHaveValue(initialPrompt.categoryId);
-  });
-
-  it('allows typing into title and content fields', () => {
-    renderForm();
-    const titleInput = screen.getByLabelText(/title/i);
-    const contentTextarea = screen.getByLabelText(/content/i);
-
-    fireEvent.change(titleInput, { target: { value: 'New Title' } });
-    fireEvent.change(contentTextarea, { target: { value: 'New Content' } });
-
-    expect(titleInput).toHaveValue('New Title');
-    expect(contentTextarea).toHaveValue('New Content');
-  });
-
-  it('allows selecting an existing category', () => {
-    renderForm();
-    const categorySelect = screen.getByLabelText(/category/i);
-    fireEvent.change(categorySelect, { target: { value: 'cat2' } });
-    expect(categorySelect).toHaveValue('cat2');
-  });
-
-  // This test assumes react-select or a similar creatable select component.
-  // If it's a standard select, "creating" a new category might involve a separate button/modal.
-  // The current PromptForm uses a Combobox which allows creating new categories.
-  it('allows creating a new category and calls addCategory', async () => {
-    renderForm();
-    const categoryInput = screen.getByRole('combobox'); // Assuming combobox role for react-select
-    
-    fireEvent.focus(categoryInput); // Open the dropdown/input area
-    fireEvent.change(categoryInput, { target: { value: 'New Test Category' } });
-
-    // Check if "Create New Test Category" option appears
-    // Wait for the "Create" option to appear in the dropdown
-    const createOption = await screen.findByText(/Create "New Test Category"/i);
-    expect(createOption).toBeInTheDocument();
-    fireEvent.click(createOption);
-
-    await waitFor(() => {
-      expect(localStorageUtils.addCategory).toHaveBeenCalledWith('New Test Category');
+  describe('Category Combobox: Display and Initial Value', () => {
+    it('shows placeholder when no initialData is provided', () => {
+      renderPromptForm();
+      // The trigger button for the combobox
+      const categoryComboboxTrigger = screen.getByRole('combobox', { name: /category/i });
+      expect(categoryComboboxTrigger).toHaveTextContent(/select or create category.../i);
     });
-    
-    // After adding, the new category should be selected.
-    // The value might be the ID of the newly created category.
-    // We mocked addCategory to return { id: 'new-New Test Category', name: 'New Test Category' }
-    await waitFor(() => {
-      expect(categoryInput).toHaveValue('New Test Category'); // Check if the input field shows the new category name
-      // Or, if the underlying select value updates to the new ID:
-      // expect(screen.getByLabelText(/category/i)).toHaveValue('new-New Test Category');
+
+    it('shows category name when initialData has a valid categoryId', () => {
+      const initialPrompt: Prompt = {
+        id: 'p1',
+        name: 'Test Prompt',
+        content: 'Test Content',
+        categoryId: 'cat1', // Exists in mockCategories
+        createdAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString(),
+      };
+      renderPromptForm({ initialData: initialPrompt });
+      const categoryComboboxTrigger = screen.getByRole('combobox', { name: /category/i });
+      expect(categoryComboboxTrigger).toHaveTextContent(mockCategories[0].name); // "Category 1"
     });
-  });
-  
-  it('calls onCancel when cancel button is clicked', () => {
-    renderForm();
-    fireEvent.click(screen.getByRole('button', { name: /cancel/i }));
-    expect(onCancelMock).toHaveBeenCalledTimes(1);
-  });
 
-  describe('Form Submission', () => {
-    it('calls onSubmit with correct data for a new prompt when valid', async () => {
-      renderForm();
-      const titleInput = screen.getByLabelText(/title/i);
-      const contentTextarea = screen.getByLabelText(/content/i);
-      // const categorySelect = screen.getByLabelText(/category/i); // This is the hidden select - REMOVED
-
-      fireEvent.change(titleInput, { target: { value: 'Valid Title' } });
-      fireEvent.change(contentTextarea, { target: { value: 'Valid Content' } });
-      // For category, we need to interact with the Combobox
-      const categoryCombobox = screen.getByRole('combobox');
-      fireEvent.focus(categoryCombobox);
-      // Select an existing category from the dropdown
-      const categoryOption = await screen.findByText('Category 1'); // Text of the option
-      fireEvent.click(categoryOption);
-
-
-      fireEvent.submit(screen.getByRole('button', { name: /save/i }));
-
-      await waitFor(() => {
-        expect(onSubmitMock).toHaveBeenCalledWith({
-          title: 'Valid Title',
-          content: 'Valid Content',
-          categoryId: 'cat1', // ID of "Category 1"
-        });
-      });
+    it('shows "Create <categoryName>" in trigger if initialData.categoryName is set but not in categories list', () => {
+      // This scenario assumes that if initialData has a categoryId not in the list,
+      // but somehow a category name was derived (e.g. if PromptForm's useEffect sets categoryName directly
+      // from a non-existent category, or if categoryId was actually a name string).
+      // Based on current PromptForm, if categoryId doesn't match, categoryName remains empty from initialData.
+      // Let's refine this: if initialData.categoryId is not found, categoryName in PromptForm becomes '',
+      // so it should show the placeholder.
+      const initialPrompt: Prompt = {
+        id: 'p2',
+        name: 'Test Prompt 2',
+        content: 'Test Content 2',
+        categoryId: 'cat-unknown', // Does NOT exist in mockCategories
+        createdAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString(),
+      };
+      renderPromptForm({ initialData: initialPrompt });
+      const categoryComboboxTrigger = screen.getByRole('combobox', { name: /category/i });
+      // In PromptForm: `const currentCategory = categories.find(cat => cat.id === initialData.categoryId);`
+      // `setCategoryName(currentCategory ? currentCategory.name : '');`
+      // So, if not found, categoryName is '', leading to placeholder.
+      expect(categoryComboboxTrigger).toHaveTextContent(/select or create category.../i);
     });
-    
-    it('calls onSubmit with correct data for an existing prompt (with initialData)', async () => {
+
+    it('shows initial categoryName in trigger if initialData has categoryId and name, even if ID is weird but name is found', () => {
+        // Test case: initialData.categoryId is 'cat1', useEffect will find 'Category 1' and set it.
         const initialPrompt: Prompt = {
-            id: 'prompt123',
-            title: 'Initial Title',
-            content: 'Initial Content',
+            id: 'p1',
+            name: 'Test Prompt',
+            content: 'Test Content',
             categoryId: 'cat1',
             createdAt: new Date().toISOString(),
             updatedAt: new Date().toISOString(),
-        };
-        renderForm(initialPrompt);
+          };
+        renderPromptForm({ initialData: initialPrompt });
+        const categoryComboboxTrigger = screen.getByRole('combobox', { name: /category/i });
+        expect(categoryComboboxTrigger).toHaveTextContent('Category 1');
+      });
+  });
 
-        const titleInput = screen.getByLabelText(/title/i);
-        const contentTextarea = screen.getByLabelText(/content/i);
-        // Update some data
-        fireEvent.change(titleInput, { target: { value: 'Updated Title' } });
-        fireEvent.change(contentTextarea, { target: { value: 'Updated Content' } });
-        
-        // Change category using the Combobox
-        const categoryCombobox = screen.getByRole('combobox');
-        fireEvent.focus(categoryCombobox);
-        const categoryOption = await screen.findByText('Category 2'); // Change to "Category 2"
-        fireEvent.click(categoryOption);
+  describe('Category Combobox: Selecting an Existing Category', () => {
+    it('allows selecting an existing category and submits with it', async () => {
+      renderPromptForm();
+      const user = userEvent.setup();
 
-        fireEvent.submit(screen.getByRole('button', { name: /save/i }));
+      // Fill out other form fields
+      await user.type(screen.getByLabelText(/name/i), 'Test Prompt Name');
+      await user.type(screen.getByLabelText(/content/i), 'Test Prompt Content');
 
-        await waitFor(() => {
-            expect(onSubmitMock).toHaveBeenCalledWith({
-                id: 'prompt123', // Ensure ID is passed through if initialData had it
-                title: 'Updated Title',
-                content: 'Updated Content',
-                categoryId: 'cat2', // ID of "Category 2"
-            });
-        });
+      // Open the category combobox
+      const categoryComboboxTrigger = screen.getByRole('combobox', { name: /category/i });
+      await user.click(categoryComboboxTrigger);
+
+      // Select "Category 2" from the list
+      // CommandItems have role 'option' in Radix Command
+      const categoryOption = await screen.findByRole('option', { name: mockCategories[1].name }); // "Category 2"
+      await user.click(categoryOption);
+
+      // Verify the trigger now shows "Category 2"
+      expect(categoryComboboxTrigger).toHaveTextContent(mockCategories[1].name);
+
+      // Submit the form
+      await user.click(screen.getByRole('button', { name: /create prompt/i }));
+
+      await waitFor(() => {
+        expect(onSubmitMock).toHaveBeenCalledWith(
+          {
+            name: 'Test Prompt Name',
+            content: 'Test Prompt Content',
+            categoryId: '', // categoryId is set by the parent component based on categoryName
+          },
+          mockCategories[1].name // Submitted category name should be "Category 2"
+        );
+      });
+    });
+  });
+
+  describe('Category Combobox: Creating a New Category', () => {
+    it('allows creating a new category and submits with it', async () => {
+      renderPromptForm();
+      const user = userEvent.setup();
+      const newCategoryName = 'My New Custom Category';
+
+      // Fill out other form fields
+      await user.type(screen.getByLabelText(/name/i), 'Another Test Prompt');
+      await user.type(screen.getByLabelText(/content/i), 'Some interesting content');
+
+      // Open the category combobox
+      const categoryComboboxTrigger = screen.getByRole('combobox', { name: /category/i });
+      await user.click(categoryComboboxTrigger);
+
+      // Type the new category name into the search input
+      const searchInput = screen.getByPlaceholderText(/search or create category.../i);
+      await user.type(searchInput, newCategoryName);
+
+      // Click the "Create new category" button
+      // This button appears in CommandEmpty, its text is "Create "{newCategoryName}""
+      const createButton = await screen.findByRole('button', { name: `Create "${newCategoryName}"` });
+      await user.click(createButton);
+
+      // Verify the trigger now shows the new category name (or part of it, like "Create ...")
+      // The current implementation of PromptForm shows `Create "Category Name"` if not found in `categories` prop,
+      // OR the actual name if it matches what's typed. After creation click, it sets `categoryName` directly.
+      // So the trigger should reflect the new name.
+      expect(categoryComboboxTrigger).toHaveTextContent(newCategoryName);
+
+      // Submit the form
+      await user.click(screen.getByRole('button', { name: /create prompt/i }));
+
+      await waitFor(() => {
+        expect(onSubmitMock).toHaveBeenCalledWith(
+          {
+            name: 'Another Test Prompt',
+            content: 'Some interesting content',
+            categoryId: '', // categoryId is set by the parent
+          },
+          newCategoryName // Submitted category name should be the new one
+        );
+      });
     });
 
-    it('does not call onSubmit and shows validation errors for empty required fields', async () => {
-      renderForm();
-      // Attempt to submit without filling anything
-      fireEvent.submit(screen.getByRole('button', { name: /save/i }));
+    it('filters suggestions when typing into search input', async () => {
+      renderPromptForm();
+      const user = userEvent.setup();
 
-      // Based on react-hook-form, validation errors should appear
+      const categoryComboboxTrigger = screen.getByRole('combobox', { name: /category/i });
+      await user.click(categoryComboboxTrigger);
+
+      const searchInput = screen.getByPlaceholderText(/search or create category.../i);
+      await user.type(searchInput, 'Another'); // Should match "Another Category"
+
+      expect(screen.getByRole('option', { name: 'Another Category' })).toBeVisible();
+      expect(screen.queryByRole('option', { name: 'Category 1' })).not.toBeInTheDocument(); // Or .not.toBeVisible() if it's just hidden
+      expect(screen.queryByRole('option', { name: 'Category 2' })).not.toBeInTheDocument();
+
+      // Clear search and check again
+      await user.clear(searchInput);
+      expect(screen.getByRole('option', { name: 'Category 1' })).toBeVisible();
+      expect(screen.getByRole('option', { name: 'Category 2' })).toBeVisible();
+      expect(screen.getByRole('option', { name: 'Another Category' })).toBeVisible();
+    });
+  });
+
+  describe('Category Combobox: Interaction with initialData', () => {
+    const promptWithCategory1: Prompt = {
+      id: 'prompt-initial-123',
+      name: 'Initial Prompt Name',
+      content: 'Initial prompt content here.',
+      categoryId: 'cat1', // "Category 1"
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    };
+
+    it('allows changing an existing category when editing a prompt', async () => {
+      renderPromptForm({ initialData: promptWithCategory1 });
+      const user = userEvent.setup();
+
+      const categoryComboboxTrigger = screen.getByRole('combobox', { name: /category/i });
+      expect(categoryComboboxTrigger).toHaveTextContent(mockCategories[0].name); // "Category 1"
+
+      // Fill out other form fields
+      await user.clear(screen.getByLabelText(/name/i));
+      await user.type(screen.getByLabelText(/name/i), 'Updated Prompt Name');
+      await user.clear(screen.getByLabelText(/content/i));
+      await user.type(screen.getByLabelText(/content/i), 'Updated Prompt Content');
+
+      // Open and change the category
+      await user.click(categoryComboboxTrigger);
+      const categoryOption2 = await screen.findByRole('option', { name: mockCategories[1].name }); // "Category 2"
+      await user.click(categoryOption2);
+      expect(categoryComboboxTrigger).toHaveTextContent(mockCategories[1].name);
+
+      // Submit the form (button should say "Save Changes")
+      await user.click(screen.getByRole('button', { name: /save changes/i }));
+
       await waitFor(() => {
-        expect(screen.getByText('Title is required.')).toBeInTheDocument();
-        expect(screen.getByText('Content is required.')).toBeInTheDocument();
-        expect(screen.getByText('Category is required.')).toBeInTheDocument();
+        expect(onSubmitMock).toHaveBeenCalledWith(
+          {
+            name: 'Updated Prompt Name',
+            content: 'Updated Prompt Content',
+            categoryId: '', // Parent handles ID resolution
+          },
+          mockCategories[1].name // New category name "Category 2"
+        );
       });
-      expect(onSubmitMock).not.toHaveBeenCalled();
+    });
+
+    it('allows creating a new category when editing a prompt', async () => {
+      renderPromptForm({ initialData: promptWithCategory1 });
+      const user = userEvent.setup();
+      const brandNewCategoryName = 'Super New Editing Category';
+
+      const categoryComboboxTrigger = screen.getByRole('combobox', { name: /category/i });
+      expect(categoryComboboxTrigger).toHaveTextContent(mockCategories[0].name); // "Category 1"
+
+      // Update other fields
+      await user.clear(screen.getByLabelText(/name/i));
+      await user.type(screen.getByLabelText(/name/i), 'Name For New Cat Edit');
+
+      // Open, type, and create new category
+      await user.click(categoryComboboxTrigger);
+      const searchInput = screen.getByPlaceholderText(/search or create category.../i);
+      await user.type(searchInput, brandNewCategoryName);
+      const createButton = await screen.findByRole('button', { name: `Create "${brandNewCategoryName}"` });
+      await user.click(createButton);
+      expect(categoryComboboxTrigger).toHaveTextContent(brandNewCategoryName);
+
+      // Submit
+      await user.click(screen.getByRole('button', { name: /save changes/i }));
+
+      await waitFor(() => {
+        expect(onSubmitMock).toHaveBeenCalledWith(
+          {
+            name: 'Name For New Cat Edit',
+            content: promptWithCategory1.content, // Content was not changed in this test
+            categoryId: '',
+          },
+          brandNewCategoryName
+        );
+      });
     });
   });
 });

--- a/src/components/custom/PromptForm.tsx
+++ b/src/components/custom/PromptForm.tsx
@@ -155,9 +155,8 @@ export const PromptForm = ({
                             <CommandItem
                               key={cat.id}
                               value={cat.name}
-                              onSelect={(currentValue) => {
-                                // currentValue is the cat.name (because of value={cat.name})
-                                // It's already in the correct casing.
+                              onSelect={() => { // currentValue parameter removed
+                                // cat.name is used directly from the outer scope
                                 setCategoryName(cat.name);
                                 setIsCategoryPopoverOpen(false);
                                 setCategorySearchText('');

--- a/yarn.lock
+++ b/yarn.lock
@@ -2584,6 +2584,11 @@
   dependencies:
     "@babel/runtime" "^7.12.5"
 
+"@testing-library/user-event@^14.6.1":
+  version "14.6.1"
+  resolved "https://registry.yarnpkg.com/@testing-library/user-event/-/user-event-14.6.1.tgz#13e09a32d7a8b7060fe38304788ebf4197cd2149"
+  integrity sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==
+
 "@tybys/wasm-util@^0.9.0":
   version "0.9.0"
   resolved "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.9.0.tgz"


### PR DESCRIPTION
This commit introduces several improvements to how categories are handled:

1.  **Prompt Form Combobox:**
    *   Replaces the category text input in the prompt creation/editing form with a Combobox.
    *   You can now select from a list of existing categories or type to create a new one on the fly.

2.  **Grouped Prompt Display:**
    *   The main page now displays prompts grouped by their respective categories.
    *   Each category has a clear header (e.g., "Category Name") at the top-left of its section.
    *   Category headers are sticky during vertical scroll for better context.
    *   Categories are sorted alphabetically, with an "Uncategorized" group appearing last.
    *   Prompts within each category maintain their sort order (newest first).

3.  **Prompt Card Update:**
    *   The category name is no longer displayed within individual prompt cards, as it's now part of the section header.

4.  **Tests:**
    *   Added unit/integration tests for the new Combobox in `PromptForm.tsx`.
    *   Added unit/integration tests for `HomePage` (`page.tsx`) to cover prompt grouping, sorting, filtering, and empty state handling.

These changes improve the organization and usability of prompts by providing a more structured and intuitive way to manage and view categories.