### PR TITLE
Fix: Ensure onboarding modal is scrollable and fits on mobile screens

### DIFF
--- a/src/components/custom/OnboardingModal.tsx
+++ b/src/components/custom/OnboardingModal.tsx
@@ -18,7 +18,7 @@ interface OnboardingModalProps {
 export const OnboardingModal = ({ isOpen, onClose }: OnboardingModalProps) => {
   return (
     <Dialog open={isOpen} onOpenChange={onClose}>
-      <DialogContent className="md:max-w-2xl overflow-y-auto">
+      <DialogContent className="md:max-w-2xl">
         <DialogHeader>
           <DialogTitle className="flex items-center">
             <Rocket className="mr-2 h-6 w-6 text-primary" />

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -57,7 +57,7 @@ function DialogContent({
       <DialogPrimitive.Content
         data-slot="dialog-content"
         className={cn(
-          "bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border p-6 shadow-lg duration-200",
+          "bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] gap-4 rounded-lg border p-6 shadow-lg duration-200 flex items-center max-h-[calc(100vh-2rem)] overflow-y-auto",
           className
         )}
         {...props}


### PR DESCRIPTION
The intro modal previously had issues on mobile devices where it could not be scrolled and did not fit into the screen, preventing you from dismissing it.

This was addressed by:
1. Modifying the base `DialogContent` component (`src/components/ui/dialog.tsx`):
    - Removed fixed vertical centering (`top-[50%]`, `translate-y-[-50%]`).
    - Added `flex items-center` to center content when it's shorter than the max height.
    - Applied a `max-h-[calc(100vh-2rem)]` to ensure the dialog's height does not exceed the viewport height (minus padding).
    - Added `overflow-y-auto` to allow the dialog itself to scroll if its content is taller than its maximum allowed height.
2. Removing a redundant `overflow-y-auto` from the `DialogContent` wrapper within `OnboardingModal.tsx` as the parent now handles this.

These changes ensure that the modal is constrained to the viewport, its content will scroll if necessary, and all interactive elements like the close and 'Get Started' buttons are accessible on mobile devices.