### PR TITLE
Fix: Center modal on mobile devices

### DIFF
--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -38,7 +38,7 @@ function DialogOverlay({
     <DialogPrimitive.Overlay
       data-slot="dialog-overlay"
       className={cn(
-        "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-black/50",
+        "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-black/50 flex items-center justify-center h-screen",
         className
       )}
       {...props}
@@ -57,7 +57,7 @@ function DialogContent({
       <DialogPrimitive.Content
         data-slot="dialog-content"
         className={cn(
-          "bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] gap-4 rounded-lg border p-6 shadow-lg duration-200 flex items-center max-h-[calc(100vh-2rem)] overflow-y-auto",
+          "bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed z-50 grid w-full max-w-[calc(100%-2rem)] gap-4 rounded-lg border p-6 shadow-lg duration-200 flex items-center max-h-[calc(100vh-2rem)] overflow-y-auto",
           className
         )}
         {...props}


### PR DESCRIPTION
Previously, modals were appearing at the bottom of the screen on mobile devices, obscuring the darkened background.

This commit modifies the `DialogContent` component in `src/components/ui/dialog.tsx` to use flexbox for centering. This ensures that modals are properly centered both vertically and horizontally on all screen sizes, including mobile.

The `DialogOverlay` now uses `flex items-center justify-center h-screen` to take up the full screen height and center the `DialogContent`. The `DialogContent` no longer needs `left-[50%]` and `translate-x-[-50%]` as flexbox handles the centering.